### PR TITLE
test(fuzz): fuzzing continuo com FUZZ_SCALE/FUZZ_SEED + nightly + UTF-8 WS (#217)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,74 @@
+name: Fuzz Nightly
+
+# Continuous fuzzing (issue #217). The per-push CI gate (ci.yml) runs the
+# socket-free fuzz runner ONCE with the deterministic regression corpus — fast,
+# reproducible, blocks merges on any crash/hang. THIS workflow complements it:
+# nightly it re-runs the same runner with a large FUZZ_SCALE and a fresh
+# per-run FUZZ_SEED, so HTTP/1, HPACK and WebSocket parsing get exercised over a
+# much wider, ever-changing input space than a single push can afford.
+#
+# Reproducing a nightly failure: the run records the exact FUZZ_SEED it used as
+# an artifact. Replay locally with the same seed for a deterministic repro:
+#   set FUZZ_SEED=<seed-from-artifact>
+#   set FUZZ_SCALE=1
+#   tests\Poseidon.FuzzRunner.exe
+# then add that seed to a regression guard once the bug is fixed.
+#
+# Self-hosted Windows runner only — Poseidon needs RAD Studio (dcc64); see ci.yml.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # 04:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      scale:
+        description: 'FUZZ_SCALE — iteration multiplier (nightly default 100)'
+        type: string
+        default: '100'
+      seed:
+        description: 'FUZZ_SEED — fixed hex/decimal salt to replay a run (blank = per-run)'
+        type: string
+        default: ''
+
+jobs:
+  fuzz:
+    runs-on: [ self-hosted, windows, delphi ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build fuzz runner
+        shell: pwsh
+        run: |
+          cmd /c "tests\build_fuzz.bat"
+          $log = Get-Content tests\build_fuzz_out.txt -Raw
+          if ($log -match '\.pas\(\d+\).*(Error|Fatal):') {
+            Write-Host $log
+            throw 'Fuzz runner failed to compile'
+          }
+          if (-not (Test-Path tests\Poseidon.FuzzRunner.exe)) { throw 'FuzzRunner.exe not produced' }
+
+      - name: Run continuous fuzz
+        shell: pwsh
+        run: |
+          $scale = '${{ github.event.inputs.scale }}'; if (-not $scale) { $scale = '100' }
+          $seed  = '${{ github.event.inputs.seed }}';  if (-not $seed)  { $seed  = "0x{0:x}" -f [int64]${{ github.run_id }} }
+          $env:FUZZ_SCALE = $scale
+          $env:FUZZ_SEED  = $seed
+          "run_id=${{ github.run_id }}`nFUZZ_SCALE=$scale`nFUZZ_SEED=$seed" | Set-Content tests\fuzz-seed.txt
+          Write-Host "Fuzzing with FUZZ_SCALE=$scale FUZZ_SEED=$seed"
+          & tests\Poseidon.FuzzRunner.exe
+          if ($LASTEXITCODE -ne 0) {
+            throw "Fuzz run FAILED (exit $LASTEXITCODE) — reproduce with FUZZ_SEED=$seed (see fuzz-seed.txt artifact)"
+          }
+
+      - name: Upload fuzz results and seed
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-nightly-${{ github.run_id }}
+          path: |
+            tests/bin/DUnitX-Fuzz-Results.xml
+            tests/fuzz-seed.txt
+            tests/build_fuzz_out.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ tests/
 - [Changelog](CHANGELOG.md)
 - [Playbook (English)](docs/playbook/README.md)
 - [Playbook (Portugues)](docs/playbook_pt-br/README.md)
+- [FuzzRunner — continuous parser fuzzing](tests/FUZZING.md)
 - [Contributing](docs/CONTRIBUTING.md)
 - [Como contribuir (pt-BR)](docs/CONTRIBUTING_pt-br.md)
 

--- a/README_pt-br.md
+++ b/README_pt-br.md
@@ -367,6 +367,7 @@ tests/
 - [Changelog](CHANGELOG.md)
 - [Playbook (English)](docs/playbook/README.md)
 - [Playbook (Portugues)](docs/playbook_pt-br/README.md)
+- [FuzzRunner — fuzzing contínuo dos parsers](tests/FUZZING.md)
 - [Contributing](docs/CONTRIBUTING.md)
 - [Como contribuir (pt-BR)](docs/CONTRIBUTING_pt-br.md)
 

--- a/docs/playbook/04-operations/testing-and-conformance.md
+++ b/docs/playbook/04-operations/testing-and-conformance.md
@@ -26,15 +26,27 @@ middlewares, plus live-socket integration fixtures for the server.
 ## In-process fuzzing
 
 `tests/Poseidon.Tests.Fuzz.pas` fuzzes the parsing surfaces that face untrusted
-bytes — `ParseHTTP1Request`, `DecodeHTTP1Chunked`, `TH2HpackCodec.DecodeHeaders`
-and `TWebSocketUtils.ParseFrame`. Each runs tens of thousands of deterministic,
-seeded inputs (random + mutated) under a watchdog thread that flags an infinite
-loop (a DoS). The invariant: **never crash, never hang, never leak an
-exception** — the parser must always return, regardless of how malformed the
-input is.
+bytes — `ParseHTTP1Request`, `DecodeHTTP1Chunked`, `TH2HpackCodec.DecodeHeaders`,
+`TWebSocketUtils.ParseFrame` and the WebSocket UTF-8 validator (`IsValidUTF8`,
+RFC 3629). Each runs tens of thousands of deterministic, seeded inputs (random +
+mutated) under a stall-based watchdog thread that flags an infinite loop (a DoS).
+The invariant: **never crash, never hang, never leak an exception** — the parser
+must always return, regardless of how malformed the input is.
+
+Fuzzing runs **continuously**, hosted by the socket-free `Poseidon.FuzzRunner`:
+
+- **Every push / PR** — `ci/run-ci.ps1` (via `.github/workflows/ci.yml`) runs the
+  runner over the deterministic regression corpus as a **hard gate**; any crash
+  blocks the merge.
+- **Nightly** — `.github/workflows/fuzz-nightly.yml` (04:00 UTC) re-runs it with a
+  large `FUZZ_SCALE` and a fresh per-run `FUZZ_SEED`, exploring a much wider input
+  space and recording the exact seed as an artifact for deterministic replay.
 
 Fuzzing already caught a real remotely-triggerable DoS in the HPACK decoder
 (invalid UTF-8 octets raised `EEncodingError`); see the security notes.
+
+> Full runner reference — knobs, fixtures, how to reproduce a nightly failure:
+> [`tests/FUZZING.md`](../../../tests/FUZZING.md).
 
 ## Dual-face compile gate
 

--- a/docs/playbook_pt-br/04-operacao-e-runtime/testes-e-conformidade.md
+++ b/docs/playbook_pt-br/04-operacao-e-runtime/testes-e-conformidade.md
@@ -27,14 +27,29 @@ além das fixtures de integração via socket real do servidor.
 
 `tests/Poseidon.Tests.Fuzz.pas` fuzza as superfícies de parsing que recebem
 bytes não confiáveis — `ParseHTTP1Request`, `DecodeHTTP1Chunked`,
-`TH2HpackCodec.DecodeHeaders` e `TWebSocketUtils.ParseFrame`. Cada uma roda
-dezenas de milhares de entradas determinísticas com seed (aleatórias +
-mutação) sob uma thread watchdog que detecta loop infinito (um DoS). A
-invariante: **nunca crashar, nunca travar, nunca vazar exceção** — o parser
-sempre retorna, por mais malformada que seja a entrada.
+`TH2HpackCodec.DecodeHeaders`, `TWebSocketUtils.ParseFrame` e o validador de
+UTF-8 do WebSocket (`IsValidUTF8`, RFC 3629). Cada uma roda dezenas de milhares
+de entradas determinísticas com seed (aleatórias + mutação) sob uma thread
+watchdog **por-stall** que detecta loop infinito (um DoS). A invariante:
+**nunca crashar, nunca travar, nunca vazar exceção** — o parser sempre retorna,
+por mais malformada que seja a entrada.
+
+O fuzzing roda de forma **contínua**, hospedado pelo `Poseidon.FuzzRunner`
+(socket-free):
+
+- **A cada push / PR** — `ci/run-ci.ps1` (via `.github/workflows/ci.yml`) roda o
+  runner sobre o corpus determinístico de regressão como **hard gate**; qualquer
+  crash bloqueia o merge.
+- **Nightly** — `.github/workflows/fuzz-nightly.yml` (04:00 UTC) re-roda com
+  `FUZZ_SCALE` grande e um `FUZZ_SEED` novo por-run, explorando um espaço de
+  entrada muito maior e gravando o seed exato como artifact para replay
+  determinístico.
 
 O fuzzing já pegou um DoS remoto real no decoder HPACK (octetos não-UTF-8
 levantavam `EEncodingError`); ver as notas de segurança.
+
+> Referência completa do runner — knobs, fixtures, como reproduzir uma falha
+> noturna: [`tests/FUZZING.md`](../../../tests/FUZZING.md).
 
 ## Gate de compilação das duas faces
 

--- a/src/Poseidon.Net.WebSocket.Manager.pas
+++ b/src/Poseidon.Net.WebSocket.Manager.pas
@@ -74,6 +74,10 @@ type
     property OnLog: TOnPoseidonLog read FOnLog write FOnLog;
   end;
 
+// Standalone UTF-8 well-formedness check (RFC 3629). Exposed so the socket-free
+// fuzzer can hammer WebSocket text/close-frame validation directly (#217).
+function IsValidUTF8(const AData: TBytes): Boolean;
+
 implementation
 
 const

--- a/tests/FUZZING.md
+++ b/tests/FUZZING.md
@@ -1,0 +1,128 @@
+# Poseidon FuzzRunner
+
+`Poseidon.FuzzRunner` is a dedicated, **socket-free** executable that fuzzes the
+Poseidon parsing surfaces — the code that faces **untrusted bytes** straight off
+the wire. Fuzzing throws tens of thousands of random, mutated and adversarial
+inputs at each parser and asserts a single invariant:
+
+> **Never crash, never hang, never leak an exception** — the parser must always
+> return, no matter how malformed the input is.
+
+A normal test checks the *happy path*. Fuzzing checks the **hostile** path — the
+one an attacker actually controls on a public HTTP server.
+
+---
+
+## Why it is a separate program
+
+The runner attacks only the **pure parsing surfaces** — no sockets, no live
+server, no Winsock/epoll dependency:
+
+| Surface | Entry point | Issue |
+|---------|-------------|-------|
+| HTTP/1 request / chunked | `ParseHTTP1Request`, `DecodeHTTP1Chunked` | #200 (smuggling) |
+| HPACK header decoder (HTTP/2) | `TH2HpackCodec.DecodeHeaders` | #201 |
+| WebSocket framing | `TWebSocketUtils.ParseFrame` | #199 |
+| WebSocket UTF-8 (RFC 3629) | `IsValidUTF8` | #217 |
+
+Because it needs no network environment, it is **fast and self-contained** — it
+can run continuously (per-push CI gate, nightly, local endurance) without the
+live-socket host the full DUnitX suite requires. That is why it lives in its own
+`.dpr` instead of inside the main suite.
+
+The fuzz fixtures live in `tests/Poseidon.Tests.Fuzz.pas`; the runner that hosts
+them is `tests/Poseidon.FuzzRunner.dpr`.
+
+---
+
+## How it works
+
+1. **Deterministic PRNG (`xorshift64`).** Each fixture is seeded with a fixed
+   base seed, so every run is **reproducible** — find a crash and the same seed
+   replays the exact byte sequence that triggered it.
+2. **Random + mutated inputs.** Each surface runs tens of thousands of
+   iterations: some buffers are pure random bytes, others start from a *valid*
+   frame / UTF-8 string and corrupt a few bytes — keeping the fuzzer near the
+   continuation / overlong / surrogate decision boundaries where bugs hide.
+3. **Invariant check.** Each buffer is fed to the parser; the test asserts it
+   never raises and never hangs.
+4. **Stall-based watchdog.** A separate thread fails the run only if the
+   iteration counter **stops advancing** — i.e. a single input drove the parser
+   into an infinite loop (a real DoS). Being per-stall rather than per-run, it
+   never false-trips however far `FUZZ_SCALE` stretches the iteration count.
+5. **Regression guards.** Known crash vectors become deterministic assertions
+   (e.g. `THPACKInvariantTests`, `TFuzzWebSocketUtf8Tests.KnownVectors_…`), so a
+   fixed bug can never silently return.
+
+Fuzzing has already caught a **real, remotely-triggerable DoS** in the HPACK
+decoder (invalid UTF-8 octets raised `EEncodingError`). That is the whole point.
+
+---
+
+## Tuning knobs (environment variables)
+
+Both default to today's exact behaviour, so the per-push gate stays fast and
+deterministic. The nightly job overrides them to explore a much wider space.
+
+| Variable | Meaning | Default |
+|----------|---------|---------|
+| `FUZZ_SCALE` | Integer ≥ 1 (capped at 1000). Multiplies the iteration count. | `1` |
+| `FUZZ_SEED`  | Hex (`0x…`) or decimal salt, XORed into every base seed — shifts the whole run to a fresh input space. | unset → `0` (deterministic regression corpus) |
+
+---
+
+## Build and run
+
+```bat
+tests\build_fuzz.bat          :: dcc64 -> tests\Poseidon.FuzzRunner.exe
+tests\Poseidon.FuzzRunner.exe :: 24 fixtures, exit 0 = all passed
+```
+
+Run a longer, freshly-salted campaign locally:
+
+```pwsh
+$env:FUZZ_SCALE = '20'
+$env:FUZZ_SEED  = '0xC0FFEE'
+tests\Poseidon.FuzzRunner.exe
+```
+
+A non-zero exit code means a crash, a failed assertion, or a watchdog stall.
+
+---
+
+## Where it runs in CI
+
+- **Every push / PR** — `.github/workflows/ci.yml` runs `ci/run-ci.ps1`, which
+  builds both platform faces and runs the FuzzRunner over the **deterministic
+  regression corpus** as a **hard gate**. Any crash blocks the merge. Fast.
+- **Nightly** — `.github/workflows/fuzz-nightly.yml` (04:00 UTC) re-runs the
+  same runner with a large `FUZZ_SCALE` and a **fresh per-run `FUZZ_SEED`**,
+  covering far more input space than a single push can afford. It records the
+  exact seed it used as a build artifact (`fuzz-seed.txt`).
+
+### Reproducing a nightly failure
+
+The failing run records its `FUZZ_SEED` in the `fuzz-nightly-<run_id>` artifact.
+Replay it locally for a deterministic repro, then add the seed to a regression
+guard once the bug is fixed:
+
+```bat
+set FUZZ_SEED=<seed-from-artifact>
+set FUZZ_SCALE=1
+tests\Poseidon.FuzzRunner.exe
+```
+
+---
+
+## Fixtures
+
+| Fixture | Covers |
+|---------|--------|
+| `TFuzzHTTP1ParserTests` | Random + mutated HTTP/1 requests and chunked bodies |
+| `TFuzzHPACKTests` | Random + structured HPACK header blocks |
+| `TFuzzWebSocketTests` | Random + mutated WebSocket frames |
+| `TFuzzWebSocketUtf8Tests` | WebSocket text/close UTF-8 validation (RFC 3629) + known vectors |
+| `THTTP1SmugglingTests` | Deterministic RFC 7230 §3.3.3 desync guards |
+| `THPACKInvariantTests` | Deterministic HPACK regression guards |
+
+See also the playbook: [Testing & Conformance](../docs/playbook/04-operations/testing-and-conformance.md).

--- a/tests/Poseidon.Tests.Fuzz.pas
+++ b/tests/Poseidon.Tests.Fuzz.pas
@@ -48,6 +48,18 @@ type
     [Test] procedure Fuzz_MutatedValidFrames_NeverCrashesNeverHangs;
   end;
 
+  // WebSocket UTF-8 validation (RFC 3629) — the check that gates text/close
+  // frames (Autobahn 6.*/7.*). Fuzzing proves the validator never crashes/hangs
+  // on adversarial byte sequences; the vectors guard proves it actually
+  // classifies well-formed vs malformed UTF-8 correctly.
+  [TestFixture]
+  TFuzzWebSocketUtf8Tests = class
+  public
+    [Test] procedure Fuzz_RandomBytes_NeverCrashesNeverHangs;
+    [Test] procedure Fuzz_MutatedValidUtf8_NeverCrashesNeverHangs;
+    [Test] procedure KnownVectors_ClassifiedCorrectly;
+  end;
+
   // Deterministic smuggling guards for the HTTP/1 parser. Fuzzing proves "never
   // crashes"; these prove the SMUGGLING defenses actively hold — each crafts the
   // exact request for one RFC 7230 §3.3.3 desync vector and asserts the parser
@@ -87,14 +99,52 @@ uses
   System.Generics.Defaults,
   Poseidon.Net.HTTP1.Parser,
   Poseidon.Net.HTTP2.HPACK,
-  Poseidon.Net.WebSocket;
+  Poseidon.Net.WebSocket,
+  Poseidon.Net.WebSocket.Manager;
 
 const
   CHTTP1Iterations = 60000;
   CHPACKIterations = 60000;
-  // Generous ceiling: 60k pure-parse iterations complete in well under this on
-  // any dev box. Overrun ⇒ an input drove an infinite loop (a real DoS bug).
+  // Stall ceiling: the watchdog fails a run only if the loop makes NO progress
+  // for this long (a single input drove an infinite loop = a real DoS bug). It
+  // is per-stall, not per-run, so it stays correct however far FUZZ_SCALE
+  // stretches the iteration count.
   CWatchdogTimeoutMs = 25000;
+
+// Continuous-fuzzing knobs (env-driven; both default to today's exact behaviour
+// so the per-push CI gate stays fast and reproducible):
+//   FUZZ_SCALE — integer >= 1, multiplies the iteration count (nightly runs it
+//                large to fuzz for much longer).
+//   FUZZ_SEED  — hex/decimal salt XORed into every base seed, so a scheduled
+//                run explores a fresh input space each night while the default
+//                (unset -> 0) keeps the deterministic regression corpus.
+function FuzzScale: Integer;
+var
+  LEnv: string;
+  LVal: Integer;
+begin
+  Result := 1;
+  LEnv := GetEnvironmentVariable('FUZZ_SCALE');
+  if (LEnv <> '') and TryStrToInt(LEnv, LVal) and (LVal >= 1) then
+  begin
+    if LVal > 1000 then LVal := 1000;   // sanity ceiling
+    Result := LVal;
+  end;
+end;
+
+function FuzzSeedSalt: UInt64;
+var
+  LEnv: string;
+  LVal: UInt64;
+begin
+  Result := 0;
+  LEnv := GetEnvironmentVariable('FUZZ_SEED');
+  if LEnv = '' then Exit;
+  if LEnv.StartsWith('0x') or LEnv.StartsWith('0X') then
+    LEnv := '$' + LEnv.Substring(2);
+  if TryStrToUInt64(LEnv, LVal) then
+    Result := LVal;
+end;
 
 // ---------------------------------------------------------------------------
 // Deterministic PRNG — xorshift64. Seeded per run; reproducible.
@@ -208,6 +258,7 @@ var
   LThread: TThread;
   LDeadline: UInt64;
   LIter: Integer;
+  LLastIter: Integer;
   LSeed: UInt64;
   LDone: Boolean;
   LErr: string;
@@ -227,10 +278,19 @@ begin
   LThread.FreeOnTerminate := True;
   LThread.Start;
 
+  // Stall-based: reset the deadline whenever the iteration counter advances, so
+  // a long (high FUZZ_SCALE) run never false-trips — only a genuinely stuck
+  // input, which stops advancing the counter, trips the watchdog.
+  LLastIter := -1;
   LDeadline := TThread.GetTickCount64 + UInt64(CWatchdogTimeoutMs);
   repeat
     TThread.Sleep(20);
     AProgress.Snapshot(LIter, LSeed, LDone);
+    if LIter <> LLastIter then
+    begin
+      LLastIter := LIter;
+      LDeadline := TThread.GetTickCount64 + UInt64(CWatchdogTimeoutMs);
+    end;
   until LDone or (TThread.GetTickCount64 >= LDeadline);
 
   if not LDone then
@@ -432,9 +492,9 @@ var
 begin
   LSeed := $DEADBEEF01234567;
   if not ARandom then LSeed := $0BADF00DCAFEBABE;
-  LRng.Seed(LSeed);
+  LRng.Seed(LSeed xor FuzzSeedSalt);
 
-  for I := 0 to CHTTP1Iterations - 1 do
+  for I := 0 to CHTTP1Iterations * FuzzScale - 1 do
   begin
     LSeed := LRng.NextU64;
     AProgress.Mark(I, LSeed);
@@ -458,8 +518,8 @@ var
   LBody: TBytes;
   LMalformed: Boolean;
 begin
-  LRng.Seed($C0FFEE0011223344);
-  for I := 0 to CHTTP1Iterations - 1 do
+  LRng.Seed($C0FFEE0011223344 xor FuzzSeedSalt);
+  for I := 0 to CHTTP1Iterations * FuzzScale - 1 do
   begin
     AProgress.Mark(I, LRng.State);
     LBuf := RandomBuf(LRng, 2048);
@@ -519,12 +579,12 @@ var
   LHeaders: TArray<TPair<string, string>>;
   LTooBig, LProtoErr: Boolean;
 begin
-  if AStructured then LRng.Seed($1234ABCD5678EF01)
-  else LRng.Seed($FEDCBA9876543210);
+  if AStructured then LRng.Seed(UInt64($1234ABCD5678EF01) xor FuzzSeedSalt)
+  else LRng.Seed(UInt64($FEDCBA9876543210) xor FuzzSeedSalt);
 
   LCodec := TH2HpackCodec.Create;
   try
-    for I := 0 to CHPACKIterations - 1 do
+    for I := 0 to CHPACKIterations * FuzzScale - 1 do
     begin
       AProgress.Mark(I, LRng.State);
       if AStructured then
@@ -587,10 +647,10 @@ var
   LFrame: TWebSocketFrame;
   LMutations, M, LPos: Integer;
 begin
-  if AMutate then LRng.Seed($55AA55AA33CC33CC)
-  else LRng.Seed($1122334455667788);
+  if AMutate then LRng.Seed(UInt64($55AA55AA33CC33CC) xor FuzzSeedSalt)
+  else LRng.Seed(UInt64($1122334455667788) xor FuzzSeedSalt);
 
-  for I := 0 to CHTTP1Iterations - 1 do
+  for I := 0 to CHTTP1Iterations * FuzzScale - 1 do
   begin
     AProgress.Mark(I, LRng.State);
     if AMutate then
@@ -636,6 +696,87 @@ begin
   finally
     LProg.Free;
   end;
+end;
+
+// Well-formed UTF-8 across the 1/2/3/4-byte ranges (é, €, U+1F600 surrogate pair).
+function ValidUtf8Sample: TBytes;
+var
+  LS: string;
+begin
+  LS := 'ascii-' + WideChar($00E9) + WideChar($20AC) + WideChar($D83D) + WideChar($DE00);
+  Result := TEncoding.UTF8.GetBytes(LS);
+end;
+
+procedure FuzzWebSocketUtf8(AProgress: TFuzzProgress; AMutate: Boolean);
+var
+  LRng: TRng;
+  I, LMut, M, LPos: Integer;
+  LBuf: TBytes;
+begin
+  if AMutate then LRng.Seed(UInt64($77CC77CC11881188) xor FuzzSeedSalt)
+  else LRng.Seed(UInt64($33445566778899AA) xor FuzzSeedSalt);
+
+  for I := 0 to CHTTP1Iterations * FuzzScale - 1 do
+  begin
+    AProgress.Mark(I, LRng.State);
+    if AMutate then
+    begin
+      // Start from valid UTF-8, corrupt a few bytes — keeps the fuzzer near the
+      // continuation/overlong/surrogate decision boundaries.
+      LBuf := ValidUtf8Sample;
+      LMut := LRng.InRange(1, 6);
+      for M := 0 to LMut - 1 do
+      begin
+        if Length(LBuf) = 0 then Break;
+        LPos := LRng.InRange(0, Length(LBuf) - 1);
+        LBuf[LPos] := LRng.NextByte;
+      end;
+    end
+    else
+      LBuf := RandomBuf(LRng, 64);
+
+    // Invariant: never raises, never hangs. The classification is checked
+    // deterministically in KnownVectors_ClassifiedCorrectly.
+    IsValidUTF8(LBuf);
+  end;
+end;
+
+procedure TFuzzWebSocketUtf8Tests.Fuzz_RandomBytes_NeverCrashesNeverHangs;
+var
+  LProg: TFuzzProgress;
+begin
+  LProg := TFuzzProgress.Create;
+  try
+    RunWithWatchdog(LProg, procedure begin FuzzWebSocketUtf8(LProg, False); end);
+  finally
+    LProg.Free;
+  end;
+end;
+
+procedure TFuzzWebSocketUtf8Tests.Fuzz_MutatedValidUtf8_NeverCrashesNeverHangs;
+var
+  LProg: TFuzzProgress;
+begin
+  LProg := TFuzzProgress.Create;
+  try
+    RunWithWatchdog(LProg, procedure begin FuzzWebSocketUtf8(LProg, True); end);
+  finally
+    LProg.Free;
+  end;
+end;
+
+procedure TFuzzWebSocketUtf8Tests.KnownVectors_ClassifiedCorrectly;
+begin
+  // Well-formed → accepted.
+  Assert.IsTrue(IsValidUTF8(TEncoding.UTF8.GetBytes('hello')), 'ASCII must validate');
+  Assert.IsTrue(IsValidUTF8(ValidUtf8Sample), 'multi-byte UTF-8 must validate');
+  Assert.IsTrue(IsValidUTF8(nil), 'empty payload is valid UTF-8');
+  // Malformed → rejected (RFC 3629 / Autobahn 6.*).
+  Assert.IsFalse(IsValidUTF8(TBytes.Create($FF)), 'lone 0xFF is never valid UTF-8');
+  Assert.IsFalse(IsValidUTF8(TBytes.Create($80)), 'lone continuation byte is invalid');
+  Assert.IsFalse(IsValidUTF8(TBytes.Create($C3)), 'truncated 2-byte lead is invalid');
+  Assert.IsFalse(IsValidUTF8(TBytes.Create($ED, $A0, $80)), 'UTF-16 surrogate (U+D800) is invalid');
+  Assert.IsFalse(IsValidUTF8(TBytes.Create($C0, $80)), 'overlong NUL encoding is invalid');
 end;
 
 // ---------------------------------------------------------------------------
@@ -900,6 +1041,7 @@ initialization
   TDUnitX.RegisterTestFixture(TFuzzHTTP1ParserTests);
   TDUnitX.RegisterTestFixture(TFuzzHPACKTests);
   TDUnitX.RegisterTestFixture(TFuzzWebSocketTests);
+  TDUnitX.RegisterTestFixture(TFuzzWebSocketUtf8Tests);
   TDUnitX.RegisterTestFixture(THTTP1SmugglingTests);
   TDUnitX.RegisterTestFixture(THPACKInvariantTests);
 


### PR DESCRIPTION
Closes #217

## O que entra
Fecha o DoD da #217 (fuzzing **contínuo** no CI, não mais one-shot):

- **CI por push** (`ci/run-ci.ps1` via `ci.yml`) já roda o `Poseidon.FuzzRunner` como hard gate — corpus determinístico, falha o build em crash/assert.
- **Nightly** (`.github/workflows/fuzz-nightly.yml`, novo): 04:00 UTC re-roda o runner com `FUZZ_SCALE` grande e `FUZZ_SEED` fresco por-noite, explorando um espaço de entrada muito maior. Grava o seed exato como artifact para replay determinístico do bug.
- **WebSocket UTF-8** (RFC 3629): expõe `IsValidUTF8` na interface do `WebSocket.Manager` e adiciona a fixture `TFuzzWebSocketUtf8Tests` (bytes aleatórios, UTF-8 válido mutado, e vetores conhecidos de classificação — surrogate U+D800, overlong NUL, continuation solto).
- **Knobs** `FUZZ_SCALE` (multiplica iterações) e `FUZZ_SEED` (salt XOR nos seeds base) — ambos default = comportamento de hoje, então o gate por-push segue rápido e determinístico.
- **Watchdog por-stall**: só falha se o contador de iterações parar de avançar (input travado = DoS real), nunca por um run longo.

## Validação
- FuzzRunner recompilado (exit 0, limpo).
- **24/24** testes no default (corpus de regressão) e também com `FUZZ_SCALE=2 FUZZ_SEED=0xABCDEF`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)